### PR TITLE
Added Dark/Light Mode Toggle for Homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,14 +4,64 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Random Excuse Generator</title>
+    <title>🎭 Excuse Generator</title>
     <link rel="stylesheet" href="styles.css">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
 </head>
 
 <body>
-    <h1>Random Excuse Generator</h1>
-    <button id="generate-btn">Generate Excuse</button>
-    <p id="excuse-display">Click the button to get a random excuse!</p>
+    <!-- Animated Background -->
+    <div class="background-animation"></div>
+
+    <!-- Theme Toggle -->
+    <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark/light mode">
+        <i class="fas fa-moon"></i>
+        <i class="fas fa-sun"></i>
+    </button>
+
+    <!-- Main Container -->
+    <div class="container">
+        <!-- Header -->
+        <header class="header">
+            <div class="logo">
+                <span class="logo-icon">🎭</span>
+                <h1 class="logo-text">Excuse<span class="highlight">Generator</span></h1>
+            </div>
+            <p class="subtitle">Your creative alibi assistant</p>
+        </header>
+
+        <!-- Main Content -->
+        <main class="main-content">
+            <!-- Excuse Display Card -->
+            <div class="excuse-card">
+                <div class="excuse-content">
+                    <p id="excuse-display" class="excuse-text">
+                        Ready to craft the perfect excuse? Click the button below!
+                    </p>
+                </div>
+                <div class="excuse-actions" id="excuse-actions" style="display: none;">
+                    <button class="action-btn" id="copy-btn" title="Copy excuse">
+                        <i class="fas fa-copy"></i>
+                    </button>
+                    <button class="action-btn" id="share-btn" title="Share excuse">
+                        <i class="fas fa-share"></i>
+                    </button>
+                </div>
+            </div>
+
+            <!-- Generate Button -->
+            <div class="generate-section">
+                <button id="generate-btn" class="generate-btn">
+                    <span class="btn-content">
+                        <i class="fas fa-magic"></i>
+                        <span class="btn-text">Generate Excuse</span>
+                    </span>
+                </button>
+            </div>
+        </main>
+    </div>
+
     <script src="script.js"></script>
 </body>
 

--- a/script.js
+++ b/script.js
@@ -1,19 +1,180 @@
+// Global variables
 let excuses = [];
+let currentExcuse = '';
 
-fetch('excuses.json')
-  .then(response => response.json())
-  .then(data => {
-    excuses = data;
-  })
-  .catch(err => {
-    console.error('Failed to load excuses:', err);
-  });
+// Theme management
+const themeToggle = document.getElementById('theme-toggle');
+const body = document.body;
+const currentTheme = localStorage.getItem('theme') || 'light';
 
-document.getElementById('generate-btn').addEventListener('click', () => {
-  if (excuses.length === 0) return;
+// Apply saved theme
+if (currentTheme === 'dark') {
+    body.setAttribute('data-theme', 'dark');
+}
 
-  const randomIndex = Math.floor(Math.random() * excuses.length);
-  const excuse = excuses[randomIndex];
+// DOM elements
+const generateBtn = document.getElementById('generate-btn');
+const excuseDisplay = document.getElementById('excuse-display');
+const excuseActions = document.getElementById('excuse-actions');
+const copyBtn = document.getElementById('copy-btn');
+const shareBtn = document.getElementById('share-btn');
 
-  document.getElementById('excuse-display').textContent = excuse;
+// Initialize app
+document.addEventListener('DOMContentLoaded', () => {
+    loadExcuses();
+    setupEventListeners();
 });
+
+// Load excuses from JSON
+async function loadExcuses() {
+    try {
+        const response = await fetch('excuses.json');
+        if (!response.ok) throw new Error('Failed to load excuses');
+        excuses = await response.json();
+    } catch (err) {
+        console.error('Failed to load excuses:', err);
+        // Fallback excuses
+        excuses = [
+            "My creativity is temporarily out of order.",
+            "The excuse generator is having an existential crisis.",
+            "All my excuses are currently being peer-reviewed."
+        ];
+    }
+}
+
+// Setup event listeners
+function setupEventListeners() {
+    // Theme toggle
+    themeToggle.addEventListener('click', toggleTheme);
+    
+    // Generate button
+    generateBtn.addEventListener('click', handleGenerateExcuse);
+    
+    // Action buttons
+    copyBtn.addEventListener('click', copyExcuse);
+    shareBtn.addEventListener('click', shareExcuse);
+    
+    // Keyboard shortcuts
+    document.addEventListener('keydown', handleKeyboardShortcuts);
+}
+
+// Theme toggle functionality
+function toggleTheme() {
+    const currentTheme = body.getAttribute('data-theme');
+    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+    
+    body.setAttribute('data-theme', newTheme);
+    localStorage.setItem('theme', newTheme);
+    
+    // Add animation to theme toggle button
+    themeToggle.style.transform = 'scale(0.8) rotate(360deg)';
+    setTimeout(() => {
+        themeToggle.style.transform = '';
+    }, 300);
+}
+
+// Main excuse generation
+async function handleGenerateExcuse() {
+    if (excuses.length === 0) return;
+    
+    // Add loading state
+    generateBtn.disabled = true;
+    generateBtn.innerHTML = `
+        <span class="btn-content">
+            <i class="fas fa-spinner fa-spin"></i>
+            <span class="btn-text">Crafting...</span>
+        </span>
+    `;
+    
+    // Simulate slight delay for better UX
+    await new Promise(resolve => setTimeout(resolve, 500));
+    
+    const randomIndex = Math.floor(Math.random() * excuses.length);
+    currentExcuse = excuses[randomIndex];
+    
+    // Display the excuse
+    excuseDisplay.textContent = currentExcuse;
+    
+    // Show action buttons
+    excuseActions.classList.add('show');
+    
+    // Reset generate button
+    generateBtn.disabled = false;
+    generateBtn.innerHTML = `
+        <span class="btn-content">
+            <i class="fas fa-magic"></i>
+            <span class="btn-text">Generate Another</span>
+        </span>
+    `;
+}
+
+// Copy excuse to clipboard
+async function copyExcuse() {
+    if (!currentExcuse) return;
+    
+    try {
+        await navigator.clipboard.writeText(currentExcuse);
+        
+        // Animation feedback
+        copyBtn.style.transform = 'scale(1.2)';
+        setTimeout(() => {
+            copyBtn.style.transform = '';
+        }, 200);
+    } catch (err) {
+        // Fallback for older browsers
+        const textArea = document.createElement('textarea');
+        textArea.value = currentExcuse;
+        document.body.appendChild(textArea);
+        textArea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textArea);
+    }
+}
+
+// Share excuse functionality
+async function shareExcuse() {
+    if (!currentExcuse) return;
+    
+    const shareData = {
+        title: 'My Creative Excuse',
+        text: currentExcuse,
+        url: window.location.href
+    };
+    
+    try {
+        if (navigator.share) {
+            await navigator.share(shareData);
+        } else {
+            // Fallback - copy to clipboard with additional text
+            const shareText = `"${currentExcuse}"\n\nGenerated by Excuse Generator: ${window.location.href}`;
+            await navigator.clipboard.writeText(shareText);
+        }
+    } catch (err) {
+        console.error('Error sharing:', err);
+    }
+}
+
+// Keyboard shortcuts
+function handleKeyboardShortcuts(e) {
+    // Spacebar or Enter to generate
+    if (e.code === 'Space' || e.code === 'Enter') {
+        if (e.target === document.body) {
+            e.preventDefault();
+            handleGenerateExcuse();
+        }
+    }
+    
+    // Ctrl+C to copy
+    if (e.ctrlKey && e.code === 'KeyC' && currentExcuse) {
+        if (e.target === document.body) {
+            e.preventDefault();
+            copyExcuse();
+        }
+    }
+    
+    // Ctrl+D to toggle theme
+    if (e.ctrlKey && e.code === 'KeyD') {
+        e.preventDefault();
+        toggleTheme();
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,27 +1,408 @@
+/* Reset and Base Styles */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  /* Light Theme Colors */
+  --primary-color: #6366f1;
+  --secondary-color: #8b5cf6;
+  --accent-color: #f59e0b;
+  --background-start: #667eea;
+  --background-end: #764ba2;
+  --surface-color: rgba(255, 255, 255, 0.25);
+  --surface-border: rgba(255, 255, 255, 0.18);
+  --text-primary: #1f2937;
+  --text-light: rgba(255, 255, 255, 0.9);
+  --shadow-color: rgba(0, 0, 0, 0.1);
+  --blur-amount: 20px;
+}
+
+[data-theme="dark"] {
+  /* Dark Theme Colors */
+  --background-start: #1a1a2e;
+  --background-end: #16213e;
+  --surface-color: rgba(255, 255, 255, 0.1);
+  --surface-border: rgba(255, 255, 255, 0.2);
+  --text-primary: #f9fafb;
+  --shadow-color: rgba(0, 0, 0, 0.3);
+}
+
 body {
-  font-family: Arial, sans-serif;
-  text-align: center;
-  padding: 50px;
-  background-color: #f9f9f9;
+  font-family: 'Poppins', sans-serif;
+  line-height: 1.6;
+  color: var(--text-primary);
+  background: linear-gradient(135deg, var(--background-start) 0%, var(--background-end) 100%);
+  min-height: 100vh;
+  overflow-x: hidden;
+  position: relative;
 }
 
-button {
-  padding: 10px 20px;
-  font-size: 1.2rem;
-  cursor: pointer;
+/* Animated Background */
+.background-animation {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  overflow: hidden;
+}
+
+.background-animation::before,
+.background-animation::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  opacity: 0.1;
+  animation: float 15s ease-in-out infinite;
+}
+
+.background-animation::before {
+  width: 300px;
+  height: 300px;
+  background: var(--primary-color);
+  top: 20%;
+  left: 10%;
+  animation-delay: 0s;
+}
+
+.background-animation::after {
+  width: 200px;
+  height: 200px;
+  background: var(--secondary-color);
+  top: 60%;
+  right: 10%;
+  animation-delay: 7s;
+}
+
+/* Theme Toggle */
+.theme-toggle {
+  position: fixed;
+  top: 2rem;
+  right: 2rem;
+  width: 60px;
+  height: 60px;
   border: none;
-  background-color: #007BFF;
+  border-radius: 50%;
+  background: var(--surface-color);
+  backdrop-filter: blur(var(--blur-amount));
+  border: 1px solid var(--surface-border);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  color: var(--text-light);
+  transition: all 0.3s ease;
+  z-index: 1000;
+  box-shadow: 0 8px 32px var(--shadow-color);
+}
+
+.theme-toggle:hover {
+  transform: scale(1.1);
+}
+
+.theme-toggle i {
+  position: absolute;
+  transition: all 0.3s ease;
+}
+
+.theme-toggle .fa-sun {
+  opacity: 0;
+  transform: rotate(180deg);
+}
+
+[data-theme="dark"] .theme-toggle .fa-moon {
+  opacity: 0;
+  transform: rotate(-180deg);
+}
+
+[data-theme="dark"] .theme-toggle .fa-sun {
+  opacity: 1;
+  transform: rotate(0deg);
+}
+
+/* Container */
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+  position: relative;
+  z-index: 1;
+}
+
+/* Header */
+.header {
+  text-align: center;
+  margin-bottom: 3rem;
+  animation: slideInDown 1s ease-out;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.logo-icon {
+  font-size: 3rem;
+  animation: bounce 2s ease-in-out infinite;
+}
+
+.logo-text {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--text-light);
+  text-shadow: 0 2px 10px var(--shadow-color);
+}
+
+.highlight {
+  background: linear-gradient(45deg, var(--primary-color), var(--secondary-color));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.subtitle {
+  font-size: 1.1rem;
+  color: var(--text-light);
+  opacity: 0.8;
+  font-weight: 300;
+}
+
+/* Main Content */
+.main-content {
+  animation: slideInUp 1s ease-out 0.3s both;
+}
+
+/* Excuse Card */
+.excuse-card {
+  background: var(--surface-color);
+  backdrop-filter: blur(var(--blur-amount));
+  border: 1px solid var(--surface-border);
+  border-radius: 24px;
+  padding: 2.5rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 20px 60px var(--shadow-color);
+  position: relative;
+  overflow: hidden;
+  transition: all 0.3s ease;
+}
+
+.excuse-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 25px 70px var(--shadow-color);
+}
+
+.excuse-content {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.excuse-text {
+  font-size: 1.3rem;
+  line-height: 1.7;
+  color: var(--text-light);
+  font-weight: 400;
+  min-height: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Excuse Actions */
+.excuse-actions {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: all 0.3s ease;
+}
+
+.excuse-actions.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.action-btn {
+  width: 45px;
+  height: 45px;
+  border: none;
+  border-radius: 50%;
+  background: var(--surface-color);
+  border: 1px solid var(--surface-border);
+  color: var(--text-light);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease;
+  font-size: 1rem;
+}
+
+.action-btn:hover {
+  transform: scale(1.2);
+  background: var(--primary-color);
+  box-shadow: 0 8px 25px rgba(99, 102, 241, 0.4);
+}
+
+/* Generate Section */
+.generate-section {
+  text-align: center;
+}
+
+.generate-btn {
+  position: relative;
+  padding: 1rem 2.5rem;
+  font-size: 1.2rem;
+  font-weight: 600;
   color: white;
-  border-radius: 5px;
+  background: linear-gradient(45deg, var(--primary-color), var(--secondary-color));
+  border: none;
+  border-radius: 50px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 10px 30px rgba(99, 102, 241, 0.3);
 }
 
-button:hover {
-  background-color: #0056b3;
+.generate-btn:hover {
+  transform: translateY(-3px) scale(1.05);
+  box-shadow: 0 15px 40px rgba(99, 102, 241, 0.4);
 }
 
-#excuse-display {
-  margin-top: 20px;
-  font-size: 1.5rem;
-  color: #333;
-  min-height: 2em;
+.generate-btn:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.btn-content {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+/* Animations */
+@keyframes float {
+  0%, 100% {
+    transform: translateY(0px) rotate(0deg);
+  }
+  50% {
+    transform: translateY(-20px) rotate(10deg);
+  }
+}
+
+@keyframes bounce {
+  0%, 20%, 50%, 80%, 100% {
+    transform: translateY(0);
+  }
+  40% {
+    transform: translateY(-10px);
+  }
+  60% {
+    transform: translateY(-5px);
+  }
+}
+
+@keyframes slideInDown {
+  from {
+    opacity: 0;
+    transform: translateY(-50px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideInUp {
+  from {
+    opacity: 0;
+    transform: translateY(50px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .container {
+    padding: 1rem;
+  }
+
+  .logo-text {
+    font-size: 2rem;
+  }
+
+  .logo-icon {
+    font-size: 2.5rem;
+  }
+
+  .excuse-card {
+    padding: 1.5rem;
+  }
+
+  .excuse-text {
+    font-size: 1.1rem;
+  }
+
+  .generate-btn {
+    padding: 0.8rem 2rem;
+    font-size: 1.1rem;
+  }
+
+  .theme-toggle {
+    width: 50px;
+    height: 50px;
+    top: 1rem;
+    right: 1rem;
+  }
+
+  .background-animation::before,
+  .background-animation::after {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .logo {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .logo-text {
+    font-size: 1.8rem;
+  }
+
+  .excuse-card {
+    padding: 1rem;
+  }
+
+  .excuse-text {
+    font-size: 1rem;
+  }
+
+  .btn-content {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .action-btn {
+    width: 40px;
+    height: 40px;
+  }
+}
+
+/* Focus styles for accessibility */
+button:focus-visible,
+.action-btn:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
 }


### PR DESCRIPTION
This PR implements a Dark/Light mode toggle, addressing issue #<number>.  

✨ **Changes Made:**  
- Added theme toggle button (top-right).  
- Implemented light and dark themes with smooth transitions.  
- Saved user’s theme preference in `localStorage` for persistence.  
- Updated excuse display and button styling to work in both themes.  

**Screenshots:**  
![Dark Mode]
<img width="1855" height="941" alt="image" src="https://github.com/user-attachments/assets/3d759f4c-1bd7-4f6f-8d26-1ac2d61b12bd" />

![Light Mode]
<img width="1859" height="942" alt="image" src="https://github.com/user-attachments/assets/3cd96bd1-e593-41da-9864-5bdafebf81ec" />

Closes #4 
